### PR TITLE
Add unix-socket-path option

### DIFF
--- a/Wallet/start_wallet.sh
+++ b/Wallet/start_wallet.sh
@@ -16,4 +16,4 @@ WALLET_POSRT="3000"
 
 
 $DATADIR/stop_wallet.sh
-$NODEOSBINDIR/keosd/keosd --config-dir $DATADIR --wallet-dir $DATADIR --http-server-address $WALLET_HOST:$WALLET_POSRT $@ & echo $! > $DATADIR/wallet.pid
+$NODEOSBINDIR/keosd/keosd --config-dir $DATADIR --wallet-dir $DATADIR --unix-socket-path $DATADIR/keosd.sock --http-server-address $WALLET_HOST:$WALLET_POSRT $@ & echo $! > $DATADIR/wallet.pid


### PR DESCRIPTION
If there's no eosio-wallet in $HOME, it would run failed. The unix-socket-path should be assigned in the script.